### PR TITLE
Increment Version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.6" %}
+{% set version = "0.1.7" %}
 
 package:
   name: pyhat


### PR DESCRIPTION
PyHAT 0.1.7 has already been released on the usgs-astrogeology channel based on the current dev branch.

I think the version should be incremented to 0.1.7 on dev, and then a PR from dev to master should be made.